### PR TITLE
Gossip small network discovery

### DIFF
--- a/text/0000-gossip-small-network-discovery.md
+++ b/text/0000-gossip-small-network-discovery.md
@@ -6,97 +6,87 @@
 
 CEP PR: [casperlabs/ceps#0000](https://github.com/casperlabs/ceps/pull/0000)
 
-The `small_net` networking component has a built-in in mechanism for node discovery that should be replaced by using the tested, central gossping component.
+The `small_net` networking component has a built-in in mechanism for node discovery that should be replaced by using the tested, central gossiping component for more robustness and simpler implementation.
 
 ## Motivation
 
 [motivation]: #motivation
 
-The current implementation for node discovery is fragile and not well tested, causing issue with nodes joining after having left the network. It is unclear whether or not the existing protocol as described in the module is free of race conditions.
+The current implementation for node discovery is fragile and not well tested, causing issues with nodes rejoining after having left the network. It is unclear whether or not the existing protocol as described in the module is fundamentally free of race conditions that would prevent a network from being eventually fully connected.
 
-This CEP suggest replacing a large portion of the `small_net` modules state and the entirety of its node discovery functionality with an instance of a `Gossiper`. The immediate advantage is the reuse of a well-tested and established component that is central to many other processes as well and reducing the amount of code actually inside the networking component.
+This CEP suggest replacing a large portion of the `small_net` components state and the entirety of its node discovery functionality with an instance of a `Gossiper`. The immediate advantage is the reuse of a well-tested and established component that is central to many other processes as well and reducing the amount of code actually inside the networking component.
 
 ## Guide-level explanation
 
 [guide-level-explanation]: #guide-level-explanation
 
-Update the current implementation of `small_net` according to the following guide:
+`small_net` is updated as follows:
 
-1. Each node starts up by connecting to one or more bootstrap addresses given at start-up.
-2. Failed or closed outgoing connections are not retried.
-3. When successly connected to a peer on an outgoing connection, add the outgoing connection to the internal connection map. This map is keyed by NodeID (derived from the public key presented), containing queues for outgoing messages.
+1. Each node starts up by initiating a connection to one or more *bootstrap* addresses set through the configuration.
+2. When successly connected to a peer through an outgoing connection, it adds the outgoing connection to the internal connection map. This map is keyed by NodeID (derived from the public key presented), containing queues for outgoing messages.
 
    This is _all_ the connection-related state `small_net` retains.
-4. All incoming connections are accepted, as long as they have a valid node id, but treated as stateless and distinct from outgoing connections (this is unchanged from the current implementation).
+3. Failed or closed outgoing connections are not retried and their respective entries remove from the connection map.
+4. All incoming connections are accepted, as long as they have a valid node id. They are treated as stateless and distinct from outgoing connections, triggering an announcement on a received message (this is unchanged from the current implementation).
 5. Every `n` seconds, each node gossips its own address.
 6. Upon receiving a gossiped address, the node will attempt to connect to it once.
 
-This proposal does away with *endpoints* entirely, as no node ever does outgoing connections "on demand".
+This proposal does away with *endpoints* entirely, as no node ever does outgoing connections "on demand", that is after being requested to send a message to specific node. The term *root node* should also be deprecated -- the network was always intended to be decentralized and calling a particular node a root node is confusing.
 
-### Example network lifetime
+(Historically, the root node was the first node whose address was known. To avoid potential bugs in practice all nodes connected to this node initially, which caused it to always have an up-to-date address list. With the update in this CEP, this should be no longer the case or necessary.)
 
+### Example networking scenario
 
+An example scenario is laid out here:
+
+1. The first node, `A`, starts up, without any bootstrapping nodes. It just opens a listening port, waiting for connections.
+2. `B` and `C` are started, with `A` as the bootstrapping node. They both connect to `A`, thus can now send messages to `A`, but will not receive any from it.
+3. `A` gossips its address, causing no change, since `B` and `C` already know `A`s address from bootstrapping.
+4. `B` and `C` gossip their addresses, causing `A` to connect to `B` and `C`, `B` to `C` and `C` to `B`.
+5. The network is now fully connected.
+6. `D` connects with `B` and `C` as bootstrapping nodes.
+7. `B` drops from the network.
+8. `A` gossips its address, causing `D` to connect to `A`.
+9. `D` gossips its address, causing `A` and `C` to connect to `D`.
+10. The network is again fully connected, with nodes that want to send messages to `B` eventually dropping them if they have not detected its failure yet.
+11. `B` rejoins, connecting to `A`.
+12. `B` gossips its address, but the gossip does not reach `C`. This causes `A` and `D` to connect to `B`.
+13. The network will be fully connected once a repeat gossip from `B` reaches `C`.
 
 ## Reference-level explanation
 
 [reference-level-explanation]: #reference-level-explanation
 
+The necessary changes to the `small_net` component include the removal of the `Endpoint`, to be replaced with just an address. Identity of nodes is established on connection securely via TLS --- remember that a nodes NodeID is just the hash of its public key and cannot be faked without knowledge of the secret key --- and the existing scheme does nothing to prevent against Sybil attacks or DDoS'ing by spamming new node announcements.
 
+Connection upgrades are handled as regular events instead of separate tasks to serialize updates to the connection mapping. The connection mapping itself is a bi-directional mapping, as we are maintaining exactly one outgoing connection per NodeId and need to remove them by NodeId as well.
 
+Any connection is tagged with an internal, monotonically increasing ID to disambiguate it, new connections with a lower ID than an established connection are ignored/closed immediately. Similarly, close/fail events only remove connections with their respective IDs. Even in the case of completely random reordering of all events, this ensures that at worst we track a dead connection to a node for a while (in the case where a connection is closed immediately and the close event overtook the open event).
 
-This is the technical portion of the CEP. Explain the design in sufficient detail that:
-
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
-
-The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+Connections are "naturally" garbage connected by being selected for gossiping; upon trying to send a message to a closed connection, a "connection closed" event is generated if the outgoing message fails.
 
 ## Drawbacks
 
 [drawbacks]: #drawbacks
 
-Why should we *not* do this?
+The previous discovery implementation aimed for an instant, complete and reliable full connection between all nodes, while this replacements delays this by up to $2 (n + \textrm{gossipDelay})$.
+
+Additionally it increases the burden on the network by gossiping addresses, instead of storing them on each node.
 
 ## Rationale and alternatives
 
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
-
-A very important thing to list here is ideas that were discarded in the process, as these tend to crop up again after a while. Describing them here saves time as it allows people discussing those ideas again in the future to refer to this document.
+This design was chosen over the existing implementation to reduce the testing burden, making it easy to prove its eventual correctness based on an already existing tested component, the gossiper.
 
 ## Prior art
 
 [prior-art]: #prior-art
 
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
-
-- For development focused proposals: Does this feature exist in other applications and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
-
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your CEP with a fuller picture.
-
-## Unresolved questions
-
-[unresolved-questions]: #unresolved-questions
-
-- What parts of the design do you expect to resolve through the CEP process before this gets merged?
-- What related issues do you consider out of scope for this CEP that could be addressed in the future independently of the solution that comes out of this CEP?
+Very few prior art (except the existing implementation) was considered for this, as this is a short-term improvement for the networking layer.
 
 ## Future possibilities
 
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would be and how it would affect the project as a whole in a holistic way. Try to use this section as a tool to more fully consider all possible interactions with the project and language in your proposal. Also consider how this all fits into the roadmap for the project and of the relevant sub-team.
-
-This is also a good place to "dump ideas", if they are out of scope for the CEP you are writing but otherwise related.
-
-If you have tried and cannot think of any future possibilities, you may simply state that you cannot think of anything.
-
-Note that having something written down in the future-possibilities section is not a reason to accept the current or a future CEP; such notes should be in the section on motivation or rationale in this or subsequent CEPs. The section merely provides additional information.
+The future for the networking layer is likely a complete replacement with either an off-the-shelf solution or a custom implementation that does not need to maintain a fully connected network with two TLS connections per graph edge. This is out of scope of this CEP.

--- a/text/0000-gossip-small-network-discovery.md
+++ b/text/0000-gossip-small-network-discovery.md
@@ -1,0 +1,102 @@
+# Gossip small network discovery
+
+## Summary
+
+[summary]: #summary
+
+CEP PR: [casperlabs/ceps#0000](https://github.com/casperlabs/ceps/pull/0000)
+
+The `small_net` networking component has a built-in in mechanism for node discovery that should be replaced by using the tested, central gossping component.
+
+## Motivation
+
+[motivation]: #motivation
+
+The current implementation for node discovery is fragile and not well tested, causing issue with nodes joining after having left the network. It is unclear whether or not the existing protocol as described in the module is free of race conditions.
+
+This CEP suggest replacing a large portion of the `small_net` modules state and the entirety of its node discovery functionality with an instance of a `Gossiper`. The immediate advantage is the reuse of a well-tested and established component that is central to many other processes as well and reducing the amount of code actually inside the networking component.
+
+## Guide-level explanation
+
+[guide-level-explanation]: #guide-level-explanation
+
+Update the current implementation of `small_net` according to the following guide:
+
+1. Each node starts up by connecting to one or more bootstrap addresses given at start-up.
+2. Failed or closed outgoing connections are not retried.
+3. When successly connected to a peer on an outgoing connection, add the outgoing connection to the internal connection map. This map is keyed by NodeID (derived from the public key presented), containing queues for outgoing messages.
+
+   This is _all_ the connection-related state `small_net` retains.
+4. All incoming connections are accepted, as long as they have a valid node id, but treated as stateless and distinct from outgoing connections (this is unchanged from the current implementation).
+5. Every `n` seconds, each node gossips its own address.
+6. Upon receiving a gossiped address, the node will attempt to connect to it once.
+
+This proposal does away with *endpoints* entirely, as no node ever does outgoing connections "on demand".
+
+### Example network lifetime
+
+
+
+## Reference-level explanation
+
+[reference-level-explanation]: #reference-level-explanation
+
+
+
+
+This is the technical portion of the CEP. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+## Drawbacks
+
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+## Rationale and alternatives
+
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+A very important thing to list here is ideas that were discarded in the process, as these tend to crop up again after a while. Describing them here saves time as it allows people discussing those ideas again in the future to refer to this document.
+
+## Prior art
+
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For development focused proposals: Does this feature exist in other applications and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your CEP with a fuller picture.
+
+## Unresolved questions
+
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the CEP process before this gets merged?
+- What related issues do you consider out of scope for this CEP that could be addressed in the future independently of the solution that comes out of this CEP?
+
+## Future possibilities
+
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would be and how it would affect the project as a whole in a holistic way. Try to use this section as a tool to more fully consider all possible interactions with the project and language in your proposal. Also consider how this all fits into the roadmap for the project and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the CEP you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities, you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section is not a reason to accept the current or a future CEP; such notes should be in the section on motivation or rationale in this or subsequent CEPs. The section merely provides additional information.

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -26,7 +26,7 @@ This CEP suggest replacing a large portion of the `small_net` components state a
 2. When successly connected to a peer through an outgoing connection, it adds the outgoing connection to the internal connection map. This map is keyed by NodeID (derived from the public key presented), containing queues for outgoing messages.
 
    This is _all_ the connection-related state `small_net` retains.
-3. Failed or closed outgoing connections are not retried and their respective entries remove from the connection map.
+3. Failed or closed outgoing connections are not retried and their respective entries removed from the connection map.
 4. All incoming connections are accepted, as long as they have a valid node id. They are treated as stateless and distinct from outgoing connections, triggering an announcement on a received message (this is unchanged from the current implementation).
 5. Every `n` seconds, each node gossips its own address.
 6. Upon receiving a gossiped address, the node will attempt to connect to it once.

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -23,7 +23,7 @@ This CEP suggest replacing a large portion of the `small_net` components state a
 `small_net` is updated as follows:
 
 1. Each node starts up by initiating a connection to one or more *bootstrap* addresses set through the configuration.
-2. When successly connected to a peer through an outgoing connection, it adds the outgoing connection to the internal connection map. This map is keyed by NodeID (derived from the public key presented), containing queues for outgoing messages.
+2. When successfully connected to a peer through an outgoing connection, it adds the outgoing connection to the internal connection map. This map is keyed by NodeID (derived from the public key presented), containing queues for outgoing messages.
 
    This is _all_ the connection-related state `small_net` retains.
 3. Failed or closed outgoing connections are not retried and their respective entries removed from the connection map.

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -41,7 +41,7 @@ An example scenario is laid out here:
 
 1. The first node, `A`, starts up, without any bootstrapping nodes. It just opens a listening port, waiting for connections.
 2. `B` and `C` are started, with `A` as the bootstrapping node. They both connect to `A`, thus can now send messages to `A`, but will not receive any from it.
-3. `A` gossips its address, causing no change, since `B` and `C` already know `A`s address from bootstrapping.
+3. `A` gossips its address, causing no change, `A` has no outgoing connections. `B` and `C` already know `A`s address from bootstrapping regardless.
 4. `B` and `C` gossip their addresses, causing `A` to connect to `B` and `C`, `B` to `C` and `C` to `B`.
 5. The network is now fully connected.
 6. `D` connects with `B` and `C` as bootstrapping nodes.

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -89,4 +89,4 @@ Very few prior art (except the existing implementation) was considered for this,
 
 [future-possibilities]: #future-possibilities
 
-The future for the networking layer is likely a complete replacement with either an off-the-shelf solution or a custom implementation that does not need to maintain a fully connected network with two TLS connections per graph edge. This is out of scope of this CEP.
+The future for the networking layer is likely a complete replacement with either an off-the-shelf solution (e.g. [libp2p](https://libp2p.io/)) or a custom implementation ([Kamdelia](https://en.wikipedia.org/wiki/Kademlia)) that does not need to maintain a fully connected network with two TLS connections per graph edge. This is out of scope of this CEP.

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -69,7 +69,7 @@ Connections are "naturally" garbage connected by being selected for gossiping; u
 
 [drawbacks]: #drawbacks
 
-The previous discovery implementation aimed for an instant, complete and reliable full connection between all nodes, while this replacements delays this by up to $2 (n + \textrm{gossipDelay})$.
+The previous discovery implementation aimed for an instant, complete and reliable full connection between all nodes, while this replacement delays this by up to $2 (n + \textrm{gossipDelay})$.
 
 Additionally it increases the burden on the network by gossiping addresses, instead of storing them on each node.
 

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -63,7 +63,7 @@ Connection upgrades are handled as regular events instead of separate tasks to s
 
 Any connection is tagged with an internal, monotonically increasing ID to disambiguate it, new connections with a lower ID than an established connection are ignored/closed immediately. Similarly, close/fail events only remove connections with their respective IDs. Even in the case of completely random reordering of all events, this ensures that at worst we track a dead connection to a node for a while (in the case where a connection is closed immediately and the close event overtook the open event).
 
-Connections are "naturally" garbage connected by being selected for gossiping; upon trying to send a message to a closed connection, a "connection closed" event is generated if the outgoing message fails.
+Connections are "naturally" garbage collected by being selected for gossiping; upon trying to send a message to a closed connection, a "connection closed" event is generated if the outgoing message fails.
 
 ## Drawbacks
 

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -52,7 +52,7 @@ An example scenario is laid out here:
 1. The network is again fully connected, with nodes that want to send messages to `B` eventually dropping them if they have not detected its failure yet.
 1. `B` rejoins, connecting to `A`.
 1. `B` gossips its address, but the gossip does not reach `C`. This causes `A` and `D` to connect to `B`.
-1. The network will be fully connected once a repeat gossip from `B` reaches `C` and `C` and `D` gossips their address reaching `B`.
+1. The network will be fully connected once a repeat gossip from `B` reaches `C` and `C` and `D` gossip their address reaching `B`.
 
 ## Reference-level explanation
 

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -4,7 +4,7 @@
 
 [summary]: #summary
 
-CEP PR: [casperlabs/ceps#0000](https://github.com/casperlabs/ceps/pull/0000)
+CEP PR: [casperlabs/ceps#10](https://github.com/casperlabs/ceps/pull/10)
 
 The `small_net` networking component has a built-in in mechanism for node discovery that should be replaced by using the tested, central gossiping component for more robustness and simpler implementation.
 

--- a/text/0010-gossip-small-network-discovery.md
+++ b/text/0010-gossip-small-network-discovery.md
@@ -40,18 +40,19 @@ This proposal does away with *endpoints* entirely, as no node ever does outgoing
 An example scenario is laid out here:
 
 1. The first node, `A`, starts up, without any bootstrapping nodes. It just opens a listening port, waiting for connections.
-2. `B` and `C` are started, with `A` as the bootstrapping node. They both connect to `A`, thus can now send messages to `A`, but will not receive any from it.
-3. `A` gossips its address, causing no change, `A` has no outgoing connections. `B` and `C` already know `A`s address from bootstrapping regardless.
-4. `B` and `C` gossip their addresses, causing `A` to connect to `B` and `C`, `B` to `C` and `C` to `B`.
-5. The network is now fully connected.
-6. `D` connects with `B` and `C` as bootstrapping nodes.
-7. `B` drops from the network.
-8. `A` gossips its address, causing `D` to connect to `A`.
-9. `D` gossips its address, causing `A` and `C` to connect to `D`.
-10. The network is again fully connected, with nodes that want to send messages to `B` eventually dropping them if they have not detected its failure yet.
-11. `B` rejoins, connecting to `A`.
-12. `B` gossips its address, but the gossip does not reach `C`. This causes `A` and `D` to connect to `B`.
-13. The network will be fully connected once a repeat gossip from `B` reaches `C`.
+1. `B` and `C` are started, with `A` as the bootstrapping node. They both connect to `A`, thus can now send messages to `A`, but will not receive any from it.
+1. `A` gossips its address, causing no change, `A` has no outgoing connections. `B` and `C` already know `A`s address from bootstrapping regardless.
+1. `B` and `C` gossip their addresses, causing `A` to connect to `B` and `C`, `B` to `C` and `C` to `B`.
+1. The second time `B` and `C` gossip their address, it is being relaid via `A` to `C` and `B` respectively.
+1. The network is now fully connected.
+1. `D` connects with `B` and `C` as bootstrapping nodes.
+1. `B` drops from the network.
+1. `D` gossips its address, causing `A` and `C` to connect to `D`.
+1. `A` gossips its address, causing `D` to connect to `A`.
+1. The network is again fully connected, with nodes that want to send messages to `B` eventually dropping them if they have not detected its failure yet.
+1. `B` rejoins, connecting to `A`.
+1. `B` gossips its address, but the gossip does not reach `C`. This causes `A` and `D` to connect to `B`.
+1. The network will be fully connected once a repeat gossip from `B` reaches `C` and `C` and `D` gossips their address reaching `B`.
 
 ## Reference-level explanation
 


### PR DESCRIPTION
[Rendered](https://github.com/CasperLabs/ceps/blob/gossip-small-network-discovery/text/0010-gossip-small-network-discovery.md)

Note: Somehow either the renaming, the fork or public/private change has really messed with the association of my fork of the `ceps` repo and the upstream one. It's in a state where I cannot make new PRs towards it, but the old ones still depend on my repo it seems.

For this reason, I am opening a branch on the actual upstream repo itself. Please do not take this as an example worthy of emulation.